### PR TITLE
Added support for more interface types in IOSXR

### DIFF
--- a/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
+++ b/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
@@ -33,7 +33,7 @@ END_PATTERN = re.compile(pattern="end$")
 IOSXR_INTERFACES_PATTERN = r"(?:Ethernet|GigabitEthernet|TenGigE|HundredGigE)"
 ETHERNET_INTERFACES = re.compile(
     pattern=fr"(^interface {IOSXR_INTERFACES_PATTERN}(?:\d|\/)+$(?:\n^\s{1}.*$)*\n!\n)+",
-    flags=re.I | re.M
+    flags=re.I | re.M,
 )
 # match mgmteth[numbers, letters, forward slashes] interface and config items below it
 MANAGEMENT_ONE_INTERFACE = re.compile(

--- a/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
+++ b/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
@@ -30,8 +30,10 @@ END_PATTERN = re.compile(pattern="end$")
 # pre-canned config section grabber patterns
 
 # match all ethernet interfaces w/ or w/out config items below them
+IOSXR_INTERFACES_PATTERN = r"(?:GigabitEthernet|TenGigE|HundredGigE)"
 ETHERNET_INTERFACES = re.compile(
-    pattern=r"(^interface \w+ethernet(?:\d|\/)+$(?:\n^\s{1}.*$)*\n!\n)+", flags=re.I | re.M
+    pattern=fr"(^interface {IOSXR_INTERFACES_PATTERN}(?:\d|\/)+$(?:\n^\s{1}.*$)*\n!\n)+",
+    flags=re.I | re.M
 )
 # match mgmteth[numbers, letters, forward slashes] interface and config items below it
 MANAGEMENT_ONE_INTERFACE = re.compile(

--- a/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
+++ b/scrapli_cfg/platform/core/cisco_iosxr/patterns.py
@@ -30,7 +30,7 @@ END_PATTERN = re.compile(pattern="end$")
 # pre-canned config section grabber patterns
 
 # match all ethernet interfaces w/ or w/out config items below them
-IOSXR_INTERFACES_PATTERN = r"(?:GigabitEthernet|TenGigE|HundredGigE)"
+IOSXR_INTERFACES_PATTERN = r"(?:Ethernet|GigabitEthernet|TenGigE|HundredGigE)"
 ETHERNET_INTERFACES = re.compile(
     pattern=fr"(^interface {IOSXR_INTERFACES_PATTERN}(?:\d|\/)+$(?:\n^\s{1}.*$)*\n!\n)+",
     flags=re.I | re.M


### PR DESCRIPTION
The current regexp for `ETHERNET_INTERFACES` in the `cisco_iosxr/patterns.py` file will not catch `TenGigE` or `HundredGigE` interfaces. 
Please see my proposed simple change in the regexp.