### PR TITLE
Add count to regex match, so only first occurance is matched

### DIFF
--- a/scrapli_cfg/platform/core/cisco_iosxe/base_platform.py
+++ b/scrapli_cfg/platform/core/cisco_iosxe/base_platform.py
@@ -160,7 +160,7 @@ class ScrapliCfgIOSXEBase:
         self.logger.debug("cleaning config file")
 
         return strip_blank_lines(
-            config=re.sub(pattern=OUTPUT_HEADER_PATTERN, string=config, repl="")
+            config=re.sub(pattern=OUTPUT_HEADER_PATTERN, string=config, repl="", count=1)
         )
 
     def _reset_config_session(self) -> None:


### PR DESCRIPTION
PR to limit the header pattern match in the XE driver to the first occurrence.

The "S" flag in the pattern match is very slow in python regex.

`OUTPUT_HEADER_PATTERN = re.compile(
    pattern=r".*(?=(version \d+\.\d+))",
    flags=re.I | re.S,
)`

Default behavior in Scrapli_Cfg is to run this regex pattern on the entire config file to remove any text before the actual configuration.

This pattern will only be seen once in a valid configuration file. This PR limits the match to the first occurrence, so that we don't have to regex the entire file, significantly speeding up the processing of the new config.

On my test config (>18000 lines), this speed up the processing from 2 hours, to less than a second, and still performed the required task of removing anything above the start of the configuration

From what i can see, the Async driver references this one, so we don't need to adjust anything there, and the other Cisco drivers don't use the "S" flag so won't have the same processing issue.

Let me know if there is anything i have missed or if you have any other contributing requirements.


Thanks
